### PR TITLE
Wip/blacklist fix

### DIFF
--- a/app/src/main/java/org/holylobster/nuntius/activity/AddApplicationBlacklist.java
+++ b/app/src/main/java/org/holylobster/nuntius/activity/AddApplicationBlacklist.java
@@ -46,6 +46,8 @@ public class AddApplicationBlacklist extends ActionBarActivity {
     private RecyclerView.LayoutManager layoutManager;
     private Toolbar toolbar;
 
+    private BlacklistedApp blacklistedApp;
+
     private List<ApplicationInfo> packages;   // All Installed App
 
     private PackageManager pm;
@@ -72,7 +74,7 @@ public class AddApplicationBlacklist extends ActionBarActivity {
     }
 
     public void addToBlacklist(int position) {
-        BlacklistedApp.add(packages.get(position));
+        blacklistedApp.add(packages.get(position));
         showInfo(position);
     }
 
@@ -85,7 +87,7 @@ public class AddApplicationBlacklist extends ActionBarActivity {
     @Override
     public void onResume(){
         super.onResume();
-        BlacklistedApp.getFromPref();
+        blacklistedApp = new BlacklistedApp(this);
     }
 
     @Override

--- a/app/src/main/java/org/holylobster/nuntius/activity/ApplicationBlacklist.java
+++ b/app/src/main/java/org/holylobster/nuntius/activity/ApplicationBlacklist.java
@@ -67,9 +67,7 @@ public class ApplicationBlacklist extends ActionBarActivity {
         pm = getPackageManager();
 
         blacklistedApp = new BlacklistedApp(this); // init the class with this context.
-
-        Log.d("test", ""+  BlacklistedApp.getBlacklistedApp());
-        adapter = new AppBlacklistAdapter(this, BlacklistedApp.getBlacklistedApp());
+        adapter = new AppBlacklistAdapter(this, blacklistedApp.getBlacklistedAppList());
 
         recyclerView.setAdapter(adapter);
         adapter.SetOnItemClickListener(new AppBlacklistAdapter.OnItemClickListener() {
@@ -81,9 +79,9 @@ public class ApplicationBlacklist extends ActionBarActivity {
     }
 
     public void itemSelected(int i) {
-        ApplicationInfo oldApp = BlacklistedApp.getBlacklistedApp().get(i);
-        BlacklistedApp.remove(i);
-        adapter.refresh(BlacklistedApp.getBlacklistedApp());
+        ApplicationInfo oldApp = blacklistedApp.getBlacklistedAppList().get(i);
+        blacklistedApp.remove(i);
+        adapter.refresh(blacklistedApp.getBlacklistedAppList());
         showInfo(oldApp);
     }
 
@@ -95,8 +93,8 @@ public class ApplicationBlacklist extends ActionBarActivity {
                         .actionListener(new ActionClickListener() {
                             @Override
                             public void onActionClicked(Snackbar snackbar) {
-                                BlacklistedApp.add(app);
-                                adapter.refresh(BlacklistedApp.getBlacklistedApp());
+                                blacklistedApp.add(app);
+                                adapter.refresh(blacklistedApp.getBlacklistedAppList());
                             }
                         }) // action button's ActionClickListener
                         .text(getString(R.string.removed_from_blacklist, pm.getApplicationLabel(app))), this);
@@ -105,10 +103,11 @@ public class ApplicationBlacklist extends ActionBarActivity {
     @Override
     public void onResume(){
         super.onResume();
-        adapter.refresh(BlacklistedApp.getBlacklistedApp());
+
+        adapter.refresh(blacklistedApp.getBlacklistedAppList());
 
         LinearLayout linearLayout = (LinearLayout) findViewById(R.id.centerLayout);
-        if(BlacklistedApp.getBlacklistedApp().size() > 0 ){
+        if (!blacklistedApp.getBlacklistedAppList().isEmpty()){
             linearLayout.setVisibility(View.GONE);
         }
     }

--- a/app/src/main/java/org/holylobster/nuntius/data/BlacklistedApp.java
+++ b/app/src/main/java/org/holylobster/nuntius/data/BlacklistedApp.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import java.util.ArrayList;
@@ -34,56 +35,55 @@ import java.util.List;
 public class BlacklistedApp {
     private static final String TAG = BlacklistedApp.class.getSimpleName();
 
-    private static List<ApplicationInfo> blacklistedApp;
-    private static Context context;
-    private static PackageManager pm;
-    private static SharedPreferences settings;
+    private List<ApplicationInfo> blacklistedAppList;
+    private Context context;
+    private PackageManager pm;
 
     public BlacklistedApp(Context c) {
         context = c;
         pm = context.getPackageManager();
-        settings = context.getSharedPreferences("BlackListSP", context.MODE_PRIVATE);
         getFromPref();
     }
 
-    public static void getFromPref(){
-        ArrayList<String> bl = new ArrayList<>(settings.getStringSet("BlackList", new HashSet<String>()));
-        blacklistedApp = new ArrayList<>();
-        for (int i = 0; i< bl.size(); i++){
+    private void getFromPref() {
+        SharedPreferences defaultSharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+        blacklistedAppList = new ArrayList<>();
+        for (String packageName : defaultSharedPreferences.getStringSet("BlackList", new HashSet<String>())) {
             try {
-                blacklistedApp.add(pm.getApplicationInfo(bl.get(i), 0));
+                blacklistedAppList.add(pm.getApplicationInfo(packageName, 0));
             } catch (PackageManager.NameNotFoundException e) {
                 Log.e(TAG, "Error retrieving application info", e);
             }
         }
-        Collections.sort(blacklistedApp, new ApplicationInfo.DisplayNameComparator(pm));
+        Collections.sort(blacklistedAppList, new ApplicationInfo.DisplayNameComparator(pm));
     }
 
-    public static List<ApplicationInfo> getBlacklistedApp(){
-        return blacklistedApp;
+    public List<ApplicationInfo> getBlacklistedAppList() {
+        return blacklistedAppList;
     }
 
-    public static void add(ApplicationInfo app){
-        blacklistedApp.add(app);
+    public void add(ApplicationInfo app) {
+        blacklistedAppList.add(app);
         sortAndPush();
     }
 
-    public static void remove(int i){
-        blacklistedApp.remove(i);
+    public void remove(int i) {
+        blacklistedAppList.remove(i);
         sortAndPush();
     }
 
-    public static void sortAndPush(){
-        Collections.sort(blacklistedApp, new ApplicationInfo.DisplayNameComparator(pm));
+    private void sortAndPush() {
+        Collections.sort(blacklistedAppList, new ApplicationInfo.DisplayNameComparator(pm));
         pushToPref();
     }
 
-    public static void pushToPref(){
-        SharedPreferences.Editor editor = settings.edit();
+    public void pushToPref() {
         ArrayList<String> bl = new ArrayList<>();
-        for (int i = 0; i< blacklistedApp.size(); i++){
-            bl.add(blacklistedApp.get(i).packageName);
+        for (ApplicationInfo applicationInfo : blacklistedAppList) {
+            bl.add(applicationInfo.packageName);
         }
+        SharedPreferences defaultSharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences.Editor editor = defaultSharedPreferences.edit();
         editor.putStringSet("BlackList", new HashSet<>(bl));
         editor.commit();
     }

--- a/app/src/main/java/org/holylobster/nuntius/notifications/NotificationListenerService.java
+++ b/app/src/main/java/org/holylobster/nuntius/notifications/NotificationListenerService.java
@@ -37,8 +37,12 @@ public class NotificationListenerService extends android.service.notification.No
         IBinder mIBinder = super.onBind(mIntent);
         Log.i(TAG, "onBind");
         isNotificationAccessEnabled = true;
-        server = new Server(this);
-        server.start();
+        try {
+            server = new Server(this);
+            server.start();
+        } catch (Exception e) {
+            Log.e(TAG, "Error during bind", e);
+        }
         return mIBinder;
     }
 
@@ -47,8 +51,12 @@ public class NotificationListenerService extends android.service.notification.No
         boolean mOnUnbind = super.onUnbind(mIntent);
         Log.i(TAG, "onUnbind");
         isNotificationAccessEnabled = false;
-        server.stop();
-        server = null;
+        try {
+            server.stop();
+            server = null;
+        } catch (Exception e) {
+            Log.e(TAG, "Error during unbind", e);
+        }
         return mOnUnbind;
     }
 


### PR DESCRIPTION
I tried to improve on top of your pull request.

This is a summary of the changes:
- preliminary fix to avoid problems in bind/unbind (unrelated to the patch, just for better testing)
- changed static variables/methods into instance variables/methods
- used default preferences instead of "BlackListSP" (was there any reason for having them separate?)
- binding the Server to receive notification when BlackList preference changes and reload

This is still not perfect but I prefer this code a lot.

Please check if there is something wrong in it or you want to improve something.
